### PR TITLE
Añadir @es-js/runtime

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@es-js/runtime",
+    "version": "0.0.1-beta.0",
+    "description": "Ejecuta EsJS y EsHtml facilmente con una etiqueta!",
+    "license": "MIT",
+    "type": "module",
+    "main": "./src/index.js",
+    "author": {
+        "name": "Creadores Program Trollhunters501",
+        "url": "https://github.com/Creadores-Program/EsJS-Script-tag"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/es-js/esjs.git",
+      "directory": "packages/runtime"
+    },
+    "keywords": [
+    "esjs",
+    "navegadores",
+    "scripts",
+    "CreadoresProgram",
+    "eshtml"
+  ]
+}

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -21,7 +21,7 @@ window.addEventListener("load", function(){
             let codigoCo2m = esJscore.compile(data);
             let element2o = document.createElement("script");
             element2o.innerHTML = codigoCo2m;
-            if(estiquetas[i].hasAttribute("mode") && etiquetas[i].getAttribute("mode") == "modulo"){
+            if(etiquetas[i].hasAttribute("mode") && etiquetas[i].getAttribute("mode") == "modulo"){
               element2o.setAttribute("type", "module");
             }
             document.body.appendChild(element2o);

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -18,13 +18,13 @@ window.addEventListener("load", function(){
       if(etiquetas[i].hasAttribute("src")){
         try{
           fetch(etiquetas[i].getAttribute("src")).then(res => res.text()).then(data => {
-            let codigoCo2m = esJscore.compile(data);
-            let element2o = document.createElement("script");
-            element2o.innerHTML = codigoCo2m;
+            let codigoCom = esJscore.compile(data);
+            let elemento = document.createElement("script");
+            elemento.innerHTML = codigoCom;
             if(etiquetas[i].hasAttribute("mode") && etiquetas[i].getAttribute("mode") == "modulo"){
-              element2o.setAttribute("type", "module");
+              elemento.setAttribute("type", "module");
             }
-            document.body.appendChild(element2o);
+            document.body.appendChild(elemento);
           }).catch(function(error){
             console.error(error);
           });

--- a/packages/runtime/src/index.js
+++ b/packages/runtime/src/index.js
@@ -1,0 +1,47 @@
+import * as esJscore from 'https://esm.run/@es-js/core';
+import * as esJseshtml from 'https://esm.run/@es-js/eshtml';
+window.addEventListener("load", function(){
+  let etiquetas = document.getElementsByTagName('script');
+  for(var i = 0; i < etiquetas.length; i++){
+    if(etiquetas[i].hasAttribute("type") && (etiquetas[i].getAttribute("type") == "text/esjs" || etiquetas[i].getAttribute("type") == "codigo/esjs")){
+      try{
+        let codigoCom = esJscore.compile(etiquetas[i].innerHTML);
+        let elemento = document.createElement("script");
+        elemento.innerHTML = codigoCom;
+        if(etiquetas[i].hasAttribute("mode") && etiquetas[i].getAttribute("mode") == "modulo"){
+          elemento.setAttribute("type", "module");
+        }
+        document.body.appendChild(elemento);
+      }catch(error){
+        console.error(error);
+      }
+      if(etiquetas[i].hasAttribute("src")){
+        try{
+          fetch(etiquetas[i].getAttribute("src")).then(res => res.text()).then(data => {
+            let codigoCo2m = esJscore.compile(data);
+            let element2o = document.createElement("script");
+            element2o.innerHTML = codigoCo2m;
+            if(estiquetas[i].hasAttribute("mode") && etiquetas[i].getAttribute("mode") == "modulo"){
+              element2o.setAttribute("type", "module");
+            }
+            document.body.appendChild(element2o);
+          }).catch(function(error){
+            console.error(error);
+          });
+        }catch(error){
+          console.error(error);
+        }
+      }
+    }
+  }
+  let etiquetasH = document.getElementsByTagName("div");
+  for(var u = 0; u < etiquetasH.length; u++){
+    if(etiquetasH[u].hasAttribute("type") && (etiquetasH[u].getAttribute("type") == "text/eshtml" || etiquetasH[u].getAttribute("type") == "codigo/eshtml")){
+      try{
+        etiquetasH[u].innerHTML = esJseshtml.compile(etiquetasH[u].innerHTML);
+      }catch(error){
+        console.error(error);
+      }
+    }
+  }
+});


### PR DESCRIPTION
Ejecuta EsJS y EsHtml facilmente con una etiqueta!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas Funciones**
  - Se ha introducido un nuevo paquete `@es-js/runtime` que mejora las capacidades de procesamiento de scripts y HTML.
  - Al cargar la ventana, se procesan etiquetas `<script>` y `<div>` con tipos específicos, compilando su contenido y manejando errores.

- **Documentación**
  - Se ha añadido un archivo `package.json` para el paquete `@es-js/runtime`, que incluye metadatos esenciales como nombre, versión, descripción y detalles del repositorio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->