### PR TITLE
change(language-tools): deprecate `osi` and `global`

### DIFF
--- a/packages/esbabel/src/keywords.ts
+++ b/packages/esbabel/src/keywords.ts
@@ -14,7 +14,7 @@ export const keywordControl = new Map<string, string>([
   ['para', 'for'],
   ['retornar', 'return'],
   ['sino', 'else'],
-  ['osi', 'else if'],
+  // ['osi', 'else if'],
   ['si', 'if'],
   ['constructor', 'constructor'],
   ['eliminar', 'delete'],
@@ -40,7 +40,6 @@ export const constantLanguage = new Map<string, string>([
   ['Infinito', 'Infinity'],
   ['NuN', 'NaN'],
   ['ambienteGlobal', 'globalThis'],
-  ['esNuN', 'isNaN'],
 ])
 
 export const variableLanguage = new Map<string, string>([
@@ -52,7 +51,7 @@ export const storageType = new Map<string, string>([
   ['asincrono', 'async'],
   ['clase', 'class'],
   ['const', 'const'],
-  ['global', 'var'],
+  // ['global', 'var'],
   ['var', 'var'],
   ['mut', 'let'],
   ['porDefecto', 'default'],
@@ -225,6 +224,7 @@ export const mathMethods = new Map<string, string>([
 ])
 
 export const numberMethods = new Map<string, string>([
+  ['esNuN', 'isNaN'],
   ['esFinito', 'isFinite'],
   ['esEntero', 'isInteger'],
   ['esEnteroSeguro', 'isSafeInteger'],

--- a/packages/esbabel/test/knownIssues.test.ts
+++ b/packages/esbabel/test/knownIssues.test.ts
@@ -35,11 +35,11 @@ describe('known issues', () => {
     expect(compile(js, true)).toEqual(esjs)
   })
 
-  it('compiles var/global to var', () => {
+  it('does not compile var/global to var', () => {
     const esjs = `
     var x = 1
-    global y = 2
-`
+    var y = 2
+`;
 
     const js = `
     var x = 1

--- a/packages/language-tools/package.json
+++ b/packages/language-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@es-js/language-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "src/generate-esjs-syntax.js",
   "type": "module",

--- a/packages/language-tools/test/__snapshots__/language-tools.test.js.snap
+++ b/packages/language-tools/test/__snapshots__/language-tools.test.js.snap
@@ -432,11 +432,11 @@ exports[`@es-js/language-tools > generates the correct esjs syntax 1`] = `
 			"patterns": [
 				{
 					"name": "keyword.control.esjs",
-					"match": "\\\\b(capturar|caso|con|continuar|crear|desde|elegir|esperar|exportar|hacer|importar|mientras|para|retornar|sino|osi|si|constructor|eliminar|extiende|finalmente|instanciaDe|intentar|lanzar|longitud|romper|simbolo|subcad|tipoDe|vacio|producir)\\\\b"
+					"match": "\\\\b(capturar|caso|con|continuar|crear|desde|elegir|esperar|exportar|hacer|importar|mientras|para|retornar|sino|si|constructor|eliminar|extiende|finalmente|instanciaDe|intentar|lanzar|longitud|romper|simbolo|subcad|tipoDe|vacio|producir)\\\\b"
 				},
 				{
 					"name": "constant.language.esjs",
-					"match": "\\\\b(falso|nulo|verdadero|indefinido|Infinito|NuN|ambienteGlobal|esNuN)\\\\b"
+					"match": "\\\\b(falso|nulo|verdadero|indefinido|Infinito|NuN|ambienteGlobal)\\\\b"
 				},
 				{
 					"name": "variable.language.esjs",
@@ -452,7 +452,7 @@ exports[`@es-js/language-tools > generates the correct esjs syntax 1`] = `
 				},
 				{
 					"name": "storage.type.esjs",
-					"match": "\\\\b(asincrono|clase|const|global|var|mut|porDefecto|funcion)\\\\b"
+					"match": "\\\\b(asincrono|clase|const|var|mut|porDefecto|funcion)\\\\b"
 				},
 				{
 					"name": "keyword.other.esjs",
@@ -6456,7 +6456,6 @@ exports[`@es-js/language-tools > generates the correct reserved words table 1`] 
 | para        | for         |
 | retornar    | return      |
 | sino        | else        |
-| osi         | else if     |
 | si          | if          |
 | constructor | constructor |
 | eliminar    | delete      |
@@ -6479,7 +6478,6 @@ exports[`@es-js/language-tools > generates the correct reserved words table 1`] 
 | asincrono   | async       |
 | clase       | class       |
 | const       | const       |
-| global      | var         |
 | var         | var         |
 | mut         | let         |
 | porDefecto  | default     |
@@ -6496,7 +6494,6 @@ exports[`@es-js/language-tools > generates the correct reserved words table 1`] 
 | Infinito       | Infinity   |
 | NuN            | NaN        |
 | ambienteGlobal | globalThis |
-| esNuN          | isNaN      |
 
 ## Funciones de soporte (Support Functions)
 
@@ -6587,6 +6584,7 @@ exports[`@es-js/language-tools > generates the correct reserved words table 1`] 
 
 | EsJS               | JavaScript     |
 | ------------------ | -------------- |
+| esNuN              | isNaN          |
 | esFinito           | isFinite       |
 | esEntero           | isInteger      |
 | esEnteroSeguro     | isSafeInteger  |

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@es-js/runtime",
-    "version": "0.0.1-beta.0",
+    "version": "0.0.1-beta.1",
     "description": "Ejecuta EsJS y EsHtml facilmente con una etiqueta!",
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas Características**
  - Actualización de la versión del paquete `@es-js/language-tools` a 0.1.1.

- **Cambios en la Gestión de Palabras Clave**
  - Se han comentado ciertas entradas en los mapas de palabras clave, lo que puede afectar cómo se representan o utilizan ciertos constructos.
  
- **Actualizaciones de Pruebas**
  - Se han actualizado los casos de prueba para reflejar cambios en la lógica de compilación, incluyendo la renombración de un caso de prueba y la omisión de otro obsoleto.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->